### PR TITLE
adds ability to pass custom header to requests

### DIFF
--- a/lib/dwolla_swagger/api/accounts_api.rb
+++ b/lib/dwolla_swagger/api/accounts_api.rb
@@ -30,7 +30,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -76,7 +76,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']

--- a/lib/dwolla_swagger/api/businessclassifications_api.rb
+++ b/lib/dwolla_swagger/api/businessclassifications_api.rb
@@ -23,7 +23,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -69,7 +69,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']

--- a/lib/dwolla_swagger/api/customers_api.rb
+++ b/lib/dwolla_swagger/api/customers_api.rb
@@ -29,7 +29,7 @@ module DwollaSwagger
       query_params[:'search'] = opts[:'search'] if opts[:'search']
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -69,7 +69,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -115,7 +115,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -162,7 +162,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -208,7 +208,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -247,7 +247,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = []
@@ -293,7 +293,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -339,7 +339,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']

--- a/lib/dwolla_swagger/api/documents_api.rb
+++ b/lib/dwolla_swagger/api/documents_api.rb
@@ -30,7 +30,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']

--- a/lib/dwolla_swagger/api/events_api.rb
+++ b/lib/dwolla_swagger/api/events_api.rb
@@ -27,7 +27,7 @@ module DwollaSwagger
       query_params[:'offset'] = opts[:'offset'] if opts[:'offset']
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -73,7 +73,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']

--- a/lib/dwolla_swagger/api/fundingsources_api.rb
+++ b/lib/dwolla_swagger/api/fundingsources_api.rb
@@ -30,7 +30,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -76,7 +76,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -123,7 +123,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -163,7 +163,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -209,7 +209,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -256,7 +256,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -302,7 +302,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -348,7 +348,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -394,7 +394,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -441,7 +441,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']

--- a/lib/dwolla_swagger/api/masspaymentitems_api.rb
+++ b/lib/dwolla_swagger/api/masspaymentitems_api.rb
@@ -30,7 +30,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -82,7 +82,7 @@ module DwollaSwagger
       query_params[:'status'] = opts[:'status'] if opts[:'status']
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']

--- a/lib/dwolla_swagger/api/masspayments_api.rb
+++ b/lib/dwolla_swagger/api/masspayments_api.rb
@@ -34,7 +34,7 @@ module DwollaSwagger
       query_params[:'offset'] = opts[:'offset'] if opts[:'offset']
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -84,7 +84,7 @@ module DwollaSwagger
       query_params[:'offset'] = opts[:'offset'] if opts[:'offset']
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -124,7 +124,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -170,7 +170,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']

--- a/lib/dwolla_swagger/api/ondemandauthorizations_api.rb
+++ b/lib/dwolla_swagger/api/ondemandauthorizations_api.rb
@@ -23,7 +23,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']

--- a/lib/dwolla_swagger/api/root_api.rb
+++ b/lib/dwolla_swagger/api/root_api.rb
@@ -23,7 +23,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -62,7 +62,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']

--- a/lib/dwolla_swagger/api/transfers_api.rb
+++ b/lib/dwolla_swagger/api/transfers_api.rb
@@ -34,7 +34,7 @@ module DwollaSwagger
       query_params[:'offset'] = opts[:'offset'] if opts[:'offset']
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -84,7 +84,7 @@ module DwollaSwagger
       query_params[:'offset'] = opts[:'offset'] if opts[:'offset']
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -124,7 +124,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -170,7 +170,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -217,7 +217,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -263,7 +263,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -309,7 +309,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']

--- a/lib/dwolla_swagger/api/webhooks_api.rb
+++ b/lib/dwolla_swagger/api/webhooks_api.rb
@@ -34,7 +34,7 @@ module DwollaSwagger
       query_params[:'offset'] = opts[:'offset'] if opts[:'offset']
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -80,7 +80,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -126,7 +126,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -172,7 +172,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']

--- a/lib/dwolla_swagger/api/webhooksubscriptions_api.rb
+++ b/lib/dwolla_swagger/api/webhooksubscriptions_api.rb
@@ -23,7 +23,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -63,7 +63,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -109,7 +109,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']
@@ -155,7 +155,7 @@ module DwollaSwagger
       query_params = {}
 
       # header parameters
-      header_params = {}
+      header_params = opts.fetch(:headers, {})
 
       # HTTP header 'Accept' (if needed)
       _header_accept = ['application/vnd.dwolla.v1.hal+json']


### PR DESCRIPTION
my editor made a ton of noise, but this is what i added to every api method

```
header_params = opts.fetch(:headers, {})
```

@EndangeredMassa we are doing this so that we can pass an idempotency key to certain requests https://docsv2.dwolla.com/#idempotency-key 
