### PR TITLE
changed header key from 'Location' to 'location' for all API methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 vendor
 .bundle
+.idea

--- a/lib/dwolla_swagger/api/accounts_api.rb
+++ b/lib/dwolla_swagger/api/accounts_api.rb
@@ -49,7 +49,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = AccountInfo.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = AccountInfo.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -95,7 +95,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:POST, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = AccountOAuthToken.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = AccountOAuthToken.new() and obj.build_from_hash(response.body))
 
     end
   end

--- a/lib/dwolla_swagger/api/businessclassifications_api.rb
+++ b/lib/dwolla_swagger/api/businessclassifications_api.rb
@@ -42,7 +42,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = BusinessClassificationListResponse.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = BusinessClassificationListResponse.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -88,7 +88,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = BusinessClassification.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = BusinessClassification.new() and obj.build_from_hash(response.body))
 
     end
   end

--- a/lib/dwolla_swagger/api/customers_api.rb
+++ b/lib/dwolla_swagger/api/customers_api.rb
@@ -48,7 +48,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = CustomerListResponse.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = CustomerListResponse.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -88,7 +88,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:POST, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = Unit.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = Unit.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -134,7 +134,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = Customer.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = Customer.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -181,7 +181,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:POST, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = Customer.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = Customer.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -227,7 +227,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = DocumentListResponse.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = DocumentListResponse.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -266,7 +266,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:POST, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = Unit.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = Unit.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -312,7 +312,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:POST, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = CustomerOAuthToken.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = CustomerOAuthToken.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -358,7 +358,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:POST, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = IavToken.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = IavToken.new() and obj.build_from_hash(response.body))
 
     end
   end

--- a/lib/dwolla_swagger/api/documents_api.rb
+++ b/lib/dwolla_swagger/api/documents_api.rb
@@ -49,7 +49,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = Document.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = Document.new() and obj.build_from_hash(response.body))
 
     end
   end

--- a/lib/dwolla_swagger/api/events_api.rb
+++ b/lib/dwolla_swagger/api/events_api.rb
@@ -46,7 +46,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = EventListResponse.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = EventListResponse.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -92,7 +92,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = ApplicationEvent.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = ApplicationEvent.new() and obj.build_from_hash(response.body))
 
     end
   end

--- a/lib/dwolla_swagger/api/fundingsources_api.rb
+++ b/lib/dwolla_swagger/api/fundingsources_api.rb
@@ -49,7 +49,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = FundingSourceListResponse.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = FundingSourceListResponse.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -95,7 +95,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = FundingSourceListResponse.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = FundingSourceListResponse.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -142,7 +142,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:POST, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = FundingSource.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = FundingSource.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -182,7 +182,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:POST, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = FundingSource.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = FundingSource.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -228,7 +228,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = FundingSource.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = FundingSource.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -275,7 +275,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:POST, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = Unit.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = Unit.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -321,7 +321,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:DELETE, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = FundingSource.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = FundingSource.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -367,7 +367,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = FundingSourceBalance.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = FundingSourceBalance.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -413,7 +413,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = MicroDeposits.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = MicroDeposits.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -460,7 +460,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:POST, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = MicroDeposits.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = MicroDeposits.new() and obj.build_from_hash(response.body))
 
     end
   end

--- a/lib/dwolla_swagger/api/masspaymentitems_api.rb
+++ b/lib/dwolla_swagger/api/masspaymentitems_api.rb
@@ -49,7 +49,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = MassPaymentItem.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = MassPaymentItem.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -101,7 +101,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = MassPaymentItemListResponse.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = MassPaymentItemListResponse.new() and obj.build_from_hash(response.body))
 
     end
   end

--- a/lib/dwolla_swagger/api/masspayments_api.rb
+++ b/lib/dwolla_swagger/api/masspayments_api.rb
@@ -53,7 +53,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = MassPaymentListResponse.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = MassPaymentListResponse.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -103,7 +103,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = MassPaymentListResponse.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = MassPaymentListResponse.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -143,7 +143,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:POST, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = Unit.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = Unit.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -189,7 +189,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = MassPayment.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = MassPayment.new() and obj.build_from_hash(response.body))
 
     end
   end

--- a/lib/dwolla_swagger/api/ondemandauthorizations_api.rb
+++ b/lib/dwolla_swagger/api/ondemandauthorizations_api.rb
@@ -42,7 +42,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:POST, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = Authorization.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = Authorization.new() and obj.build_from_hash(response.body))
 
     end
   end

--- a/lib/dwolla_swagger/api/root_api.rb
+++ b/lib/dwolla_swagger/api/root_api.rb
@@ -42,7 +42,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = CatalogResponse.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = CatalogResponse.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -81,7 +81,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:POST, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = OAuthResponse.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = OAuthResponse.new() and obj.build_from_hash(response.body))
 
     end
   end

--- a/lib/dwolla_swagger/api/transfers_api.rb
+++ b/lib/dwolla_swagger/api/transfers_api.rb
@@ -53,7 +53,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = TransferListResponse.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = TransferListResponse.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -103,7 +103,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = TransferListResponse.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = TransferListResponse.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -147,7 +147,7 @@ module DwollaSwagger
       puts response.body
       puts response.headers
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = Unit.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = Unit.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -193,7 +193,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = Transfer.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = Transfer.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -240,7 +240,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:POST, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = Transfer.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = Transfer.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -286,7 +286,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = TransferFailure.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = TransferFailure.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -332,7 +332,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = TransferListResponse.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = TransferListResponse.new() and obj.build_from_hash(response.body))
 
     end
   end

--- a/lib/dwolla_swagger/api/webhooks_api.rb
+++ b/lib/dwolla_swagger/api/webhooks_api.rb
@@ -53,7 +53,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = WebhookEventListResponse.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = WebhookEventListResponse.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -99,7 +99,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = Webhook.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = Webhook.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -145,7 +145,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = WebhookRetryRequestListResponse.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = WebhookRetryRequestListResponse.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -191,7 +191,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:POST, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = WebhookRetry.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = WebhookRetry.new() and obj.build_from_hash(response.body))
 
     end
   end

--- a/lib/dwolla_swagger/api/webhooksubscriptions_api.rb
+++ b/lib/dwolla_swagger/api/webhooksubscriptions_api.rb
@@ -42,7 +42,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = WebhookListResponse.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = WebhookListResponse.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -82,7 +82,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:POST, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = WebhookSubscription.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = WebhookSubscription.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -128,7 +128,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = WebhookSubscription.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = WebhookSubscription.new() and obj.build_from_hash(response.body))
 
     end
 
@@ -174,7 +174,7 @@ module DwollaSwagger
 
       response = Swagger::Request.new(:DELETE, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body, :auth_names => @auth_names}).make
 
-      response.code == 201 ? obj = response.headers['Location'] : (obj = WebhookSubscription.new() and obj.build_from_hash(response.body))
+      response.code == 201 ? obj = response.headers['location'] : (obj = WebhookSubscription.new() and obj.build_from_hash(response.body))
 
     end
   end


### PR DESCRIPTION
We are experiencing [these errors](https://sentry.io/organizations/popular-pays-lf/issues/2283937446/?project=261650&query=is%3Aunresolved) whenever a payment in made with Dwolla. 

This is because the header key has changed from "Location" to "location". See the example header response when creating a Dwolla transfer:

```
{
   "date":"Fri, 19 Mar 2021 18:48:50 GMT",
   "content-type":"application/vnd.dwolla.v1.hal+json",
   "content-length":"0",
   "connection":"close",
   "set-cookie":"__cfduid=d20119a5df5e48fb9be6a86cfe42723771616179729; expires=Sun, 18-Apr-21 18:48:49 GMT; path=/; domain=.dwolla.com; HttpOnly; SameSite=Lax, __cf_bm=ca5c0d15f729d14d61b01d3e576a5c883d39abc2-1616179730-1800-AV87VwLhI8SteMR/NSA4EGBjVMQBGY1L084fiAGlonDWXQoI2ZZDjOBPlZQskGZRIsjbNL3sn0iPQqgE3m2Fj9k=; path=/; expires=Fri, 19-Mar-21 19:18:50 GMT; domain=.dwolla.com; HttpOnly; Secure; SameSite=None",
   "location":"https://api-sandbox.dwolla.com/transfers/037fb3ba-e388-eb11-8130-ef8b5133104e",
   "x-request-id":"1aafffcb-6516-4c44-af81-edc3e39c36e0",
   "cf-cache-status":"DYNAMIC",
   "cf-request-id":"08ed6aac6300009dcb02066000000001",
   "expect-ct":"max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
   "server":"cloudflare",
   "cf-ray":"6328e08d6e369dcb-ORD"
}
```